### PR TITLE
feat: Add comprehensive MCP server test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dev = [
     "mypy>=1.5.0",
     "types-click>=7.1.0",
     "twine>=5.0.0",
+    "anyio>=4.0.0",
+    "pytest-xdist>=3.6.1",
 ]
 
 [build-system]
@@ -92,6 +94,8 @@ dev-dependencies = [
     "twine>=5.0.0",
     "mcp[cli]>=1.0.0",
     "pydantic>=2.0.0",
+    "anyio>=4.0.0",
+    "pytest-xdist>=3.6.1",
 ]
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,186 @@
+"""Pytest configuration for iterm2-focus tests."""
+
+import sys
+
+import pytest
+from pytest_mock import MockerFixture
+
+# Check if MCP is available
+try:
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    MCP_TEST_AVAILABLE = True
+except ImportError:
+    MCP_TEST_AVAILABLE = False
+
+# Mark to skip MCP tests
+skip_if_no_mcp = pytest.mark.skipif(
+    not MCP_TEST_AVAILABLE,
+    reason="MCP not available (requires mcp[cli] package)",
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Set anyio backend to asyncio for all tests."""
+    return "asyncio"
+
+
+if MCP_TEST_AVAILABLE:
+
+    @pytest.fixture
+    def mock_iterm2_for_mcp(mocker):
+        """Mock iTerm2 for MCP tests."""
+        mock_iterm2_module = mocker.MagicMock()
+
+        # Mock Connection class
+        mock_connection_instance = mocker.AsyncMock()
+        mock_connection_class = mocker.MagicMock()
+        mock_connection_class.async_create = mocker.AsyncMock(
+            return_value=mock_connection_instance
+        )
+        mock_iterm2_module.Connection = mock_connection_class
+
+        # Mock App
+        mock_app = mocker.MagicMock()
+        mock_iterm2_module.async_get_app = mocker.AsyncMock(return_value=mock_app)
+
+        # Mock Window
+        mock_window = mocker.MagicMock()
+        mock_window.window_id = "w0"
+        mock_window.async_activate = mocker.AsyncMock()
+
+        # Mock Tab
+        mock_tab = mocker.MagicMock()
+        mock_tab.tab_id = "t0"
+        mock_tab.async_select = mocker.AsyncMock()
+
+        # Mock Session
+        mock_session = mocker.MagicMock()
+        mock_session.session_id = "w0t0p0:12345678-1234-1234-1234-123456789012"
+        mock_session.async_activate = mocker.AsyncMock()
+        mock_session.async_get_profile = mocker.AsyncMock(
+            return_value={"Title": "Test Session", "Name": "Session Name"}
+        )
+
+        # Wire up the relationships
+        mock_tab.sessions = [mock_session]
+        mock_window.tabs = [mock_tab]
+        mock_window.current_tab = mock_tab
+        mock_tab.current_session = mock_session
+        mock_app.terminal_windows = [mock_window]
+        mock_app.windows = [mock_window]
+        mock_app.current_terminal_window = mock_window
+
+        # Patch the iterm2 module for MCP imports
+        mocker.patch("iterm2_focus.mcp.tools.iterm_tools.iterm2", mock_iterm2_module)
+
+        return mock_iterm2_module
+
+    @pytest.fixture
+    async def mcp_server(mock_iterm2_for_mcp):
+        """Create an iterm2-focus MCP server instance for testing."""
+        # Import server AFTER mock_iterm2 is set up
+        from iterm2_focus.mcp.server import mcp
+
+        return mcp
+
+    @pytest.fixture
+    async def client_session(mcp_server):
+        """Create a connected client session to the MCP server."""
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _client_session():
+            async with create_connected_server_and_client_session(
+                mcp_server._mcp_server
+            ) as client:
+                yield client
+
+        return _client_session
+
+
+@pytest.fixture(autouse=True)
+def mock_iterm2(mocker: MockerFixture, request):
+    """Mock iTerm2 API for testing without real iTerm2.
+
+    This is autouse to ensure iterm2 is always mocked in tests,
+    preventing accidental connections to real iTerm2.
+    """
+    # Skip for real integration tests
+    if "integration" in request.keywords:
+        yield None
+        return
+
+    # Skip for tests that handle their own iterm2 mocking
+    if request.node.name.startswith(
+        "test_async_focus_"
+    ) or request.node.name.startswith("test_focus_session"):
+        yield None
+        return
+
+    # Skip for MCP tests - they'll use their own mock
+    if any(
+        part in str(request.fspath)
+        for part in ["test_mcp", "test_iterm_tools", "test_utils"]
+    ):
+        yield None
+        return
+
+    # Mock the iterm2 module before any imports
+    mock_iterm2_module = mocker.MagicMock()
+
+    # Mock Connection class
+    mock_connection_instance = mocker.AsyncMock()
+    mock_connection_class = mocker.MagicMock()
+    mock_connection_class.async_create = mocker.AsyncMock(
+        return_value=mock_connection_instance
+    )
+    mock_iterm2_module.Connection = mock_connection_class
+
+    # Mock App
+    mock_app = mocker.MagicMock()
+    mock_iterm2_module.async_get_app = mocker.AsyncMock(return_value=mock_app)
+
+    # Mock Window
+    mock_window = mocker.MagicMock()
+    mock_window.window_id = "w0"
+    mock_window.async_activate = mocker.AsyncMock()
+
+    # Mock Tab
+    mock_tab = mocker.MagicMock()
+    mock_tab.tab_id = "t0"
+    mock_tab.async_select = mocker.AsyncMock()
+
+    # Mock Session
+    mock_session = mocker.MagicMock()
+    mock_session.session_id = "w0t0p0:12345678-1234-1234-1234-123456789012"
+    mock_session.async_activate = mocker.AsyncMock()
+    mock_session.async_get_profile = mocker.AsyncMock(
+        return_value={"Title": "Test Session", "Name": "Session Name"}
+    )
+
+    # Wire up the relationships
+    mock_tab.sessions = [mock_session]
+    mock_window.tabs = [mock_tab]
+    mock_window.current_tab = mock_tab
+    mock_tab.current_session = mock_session
+    mock_app.terminal_windows = [mock_window]
+    mock_app.windows = [mock_window]
+    mock_app.current_terminal_window = mock_window
+
+    # Patch the iterm2 module at import level
+    # This ensures any imports of iterm2 get the mock
+    original_iterm2 = sys.modules.get("iterm2")
+    sys.modules["iterm2"] = mock_iterm2_module
+
+    # Also patch at the import name level for dynamic imports
+    mocker.patch("iterm2_focus.mcp.tools.iterm_tools.iterm2", mock_iterm2_module)
+
+    yield mock_iterm2_module
+
+    # Restore original if it existed
+    if original_iterm2:
+        sys.modules["iterm2"] = original_iterm2
+    else:
+        sys.modules.pop("iterm2", None)

--- a/tests/test_iterm_tools.py
+++ b/tests/test_iterm_tools.py
@@ -1,0 +1,237 @@
+"""Tests for iTerm2-specific MCP tools."""
+
+import pytest
+
+from tests.conftest import MCP_TEST_AVAILABLE, skip_if_no_mcp
+
+if MCP_TEST_AVAILABLE:
+    pass
+
+
+class TestITermTools:
+    """Test iTerm2-specific MCP tools."""
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_list_sessions(self, mcp_server, client_session, mock_iterm2_for_mcp):
+        """Test list_sessions tool."""
+        async with client_session() as client:
+            result = await client.call_tool("list_sessions", {})
+
+            # Should return structured content with list of sessions
+            assert result.isError is False
+            assert result.structuredContent is not None
+            assert "result" in result.structuredContent
+
+            sessions = result.structuredContent["result"]
+            assert isinstance(sessions, list)
+            assert len(sessions) == 1
+
+            # Check session structure
+            session = sessions[0]
+            assert (
+                session["session_id"] == "w0t0p0:12345678-1234-1234-1234-123456789012"
+            )
+            assert session["window_id"] == "w0"
+            assert session["tab_id"] == "t0"
+            assert session["is_active"] is True
+            assert session["title"] == "Test Session"
+            assert session["name"] == "Session Name"
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_list_sessions_multiple(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test list_sessions with multiple sessions."""
+        # Get the mock app to access terminal windows
+        mock_app = await mock_iterm2_for_mcp.async_get_app()
+
+        # Add more sessions to the mock
+        session2 = mock_iterm2_for_mcp.MagicMock()
+        session2.session_id = "w0t0p1:another-session"
+        session2.async_get_profile = mock_iterm2_for_mcp.AsyncMock(
+            return_value={"Title": "Second Session", "Name": "Session 2"}
+        )
+
+        # Add second session to the same tab
+        mock_app.terminal_windows[0].tabs[0].sessions.append(session2)
+
+        async with client_session() as client:
+            result = await client.call_tool("list_sessions", {})
+
+            sessions = result.structuredContent["result"]
+            assert len(sessions) == 2
+
+            # Check both sessions
+            session_ids = {s["session_id"] for s in sessions}
+            assert "w0t0p0:12345678-1234-1234-1234-123456789012" in session_ids
+            assert "w0t0p1:another-session" in session_ids
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_focus_session_success(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test successful focus_session."""
+        async with client_session() as client:
+            result = await client.call_tool(
+                "focus_session",
+                {"session_id": "w0t0p0:12345678-1234-1234-1234-123456789012"},
+            )
+
+            # FocusResult returns object fields directly in structuredContent
+            assert result.isError is False
+            assert result.structuredContent is not None
+
+            # The structuredContent is the FocusResult object directly
+            assert result.structuredContent["success"] is True
+            assert (
+                result.structuredContent["session_id"]
+                == "w0t0p0:12345678-1234-1234-1234-123456789012"
+            )
+            assert "Successfully focused" in result.structuredContent["message"]
+
+            # Verify the session was activated
+            mock_app = await mock_iterm2_for_mcp.async_get_app()
+            mock_app.terminal_windows[0].async_activate.assert_called_once()
+            mock_app.terminal_windows[0].tabs[0].async_select.assert_called_once()
+            mock_app.terminal_windows[0].tabs[0].sessions[
+                0
+            ].async_activate.assert_called_once()
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_focus_session_not_found(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test focus_session with non-existent session."""
+        async with client_session() as client:
+            result = await client.call_tool(
+                "focus_session", {"session_id": "non-existent-session"}
+            )
+
+            # Should return structured content with failure
+            assert result.isError is False
+            assert result.structuredContent is not None
+
+            assert result.structuredContent["success"] is False
+            assert result.structuredContent["session_id"] == "non-existent-session"
+            assert "not found" in result.structuredContent["message"]
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_focus_session_connection_error(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test focus_session when connection fails."""
+        # Make connection fail
+        mock_iterm2_for_mcp.Connection.async_create.side_effect = ConnectionError(
+            "iTerm2 not running"
+        )
+
+        async with client_session() as client:
+            result = await client.call_tool(
+                "focus_session",
+                {"session_id": "w0t0p0:12345678-1234-1234-1234-123456789012"},
+            )
+
+            # Should return failure with connection error
+            assert result.isError is False
+            assert result.structuredContent is not None
+
+            assert result.structuredContent["success"] is False
+            assert "Failed to connect" in result.structuredContent["message"]
+            assert "iTerm2 not running" in result.structuredContent["message"]
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_get_current_session(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test get_current_session tool."""
+        async with client_session() as client:
+            result = await client.call_tool("get_current_session", {})
+
+            # Should return structured content with session info
+            assert result.isError is False
+            assert result.structuredContent is not None
+
+            # get_current_session returns SessionInfo | None, wrapped in result
+            assert "result" in result.structuredContent
+            session_info = result.structuredContent["result"]
+
+            assert session_info is not None
+            assert (
+                session_info["session_id"]
+                == "w0t0p0:12345678-1234-1234-1234-123456789012"
+            )
+            assert session_info["window_id"] == "w0"
+            assert session_info["tab_id"] == "t0"
+            assert session_info["is_active"] is True
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_get_current_session_none(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test get_current_session when no session is active."""
+        # Get mock app and remove current window
+        mock_app = await mock_iterm2_for_mcp.async_get_app()
+        mock_app.current_terminal_window = None
+
+        async with client_session() as client:
+            result = await client.call_tool("get_current_session", {})
+
+            # Should return null in structured content
+            assert result.isError is False
+            assert result.structuredContent is not None
+            assert result.structuredContent["result"] is None
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_tool_parameter_validation(self, mcp_server, client_session):
+        """Test parameter validation for tools."""
+        async with client_session() as client:
+            # focus_session without required parameter should return an error
+            result = await client.call_tool("focus_session", {})
+
+            # Should return an error result
+            assert result.isError is True
+            assert len(result.content) > 0
+            error_text = result.content[0].text.lower()
+            assert (
+                "session_id" in error_text
+                or "missing" in error_text
+                or "required" in error_text
+            )
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_tool_return_types(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test that tools return properly formatted responses."""
+        async with client_session() as client:
+            # Test list_sessions returns array
+            result = await client.call_tool("list_sessions", {})
+            assert result.structuredContent is not None
+            sessions = result.structuredContent["result"]
+            assert isinstance(sessions, list)
+
+            # Test focus_session returns object
+            result = await client.call_tool(
+                "focus_session", {"session_id": "test-session"}
+            )
+            assert result.structuredContent is not None
+            # FocusResult is returned directly as structuredContent
+            assert isinstance(result.structuredContent, dict)
+            assert "success" in result.structuredContent
+            assert "session_id" in result.structuredContent
+            assert "message" in result.structuredContent
+
+            # Test get_current_session returns object or null
+            result = await client.call_tool("get_current_session", {})
+            assert result.structuredContent is not None
+            current = result.structuredContent["result"]
+            assert current is None or isinstance(current, dict)

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,0 +1,206 @@
+"""Integration tests for iterm2-focus MCP server."""
+
+import pytest
+
+from tests.conftest import MCP_TEST_AVAILABLE, skip_if_no_mcp
+
+if MCP_TEST_AVAILABLE:
+    from iterm2_focus.mcp.__main__ import main as mcp_main
+
+
+class TestMCPIntegration:
+    """Test MCP server integration scenarios."""
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_full_workflow(self, mcp_server, client_session, mock_iterm2_for_mcp):
+        """Test a complete workflow: list sessions, get current, focus session."""
+        async with client_session() as client:
+            # Step 1: List all sessions
+            result = await client.list_tools()
+            assert len(result.tools) == 3
+
+            # Step 2: Get list of sessions
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+            assert len(sessions) > 0
+
+            # Remember the first session
+            target_session = sessions[0]
+            target_id = target_session["session_id"]
+
+            # Step 3: Get current session
+            result = await client.call_tool("get_current_session", {})
+            current = result.structuredContent["result"]
+            assert current is not None
+            assert current["session_id"] == target_id  # Should be same in our mock
+
+            # Step 4: Focus a session
+            result = await client.call_tool("focus_session", {"session_id": target_id})
+            focus_result = result.structuredContent
+            assert focus_result["success"] is True
+
+            # Verify all iTerm2 methods were called
+            assert mock_iterm2_for_mcp.Connection.async_create.called
+            assert mock_iterm2_for_mcp.async_get_app.called
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_multiple_windows_navigation(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test navigation across multiple windows."""
+        # Import AsyncMock from unittest.mock
+        from unittest.mock import AsyncMock
+
+        # Get mock app
+        mock_app = await mock_iterm2_for_mcp.async_get_app()
+
+        # Create second window with sessions
+        window2 = mock_iterm2_for_mcp.MagicMock()
+        window2.window_id = "w1"
+        window2.async_activate = AsyncMock()
+
+        tab2 = mock_iterm2_for_mcp.MagicMock()
+        tab2.tab_id = "t0"
+        tab2.async_select = AsyncMock()
+
+        session2 = mock_iterm2_for_mcp.MagicMock()
+        session2.session_id = "w1t0p0:second-window-session"
+        session2.async_activate = AsyncMock()
+        session2.async_get_profile = AsyncMock(
+            return_value={"Title": "Window 2 Session", "Name": "W2S1"}
+        )
+
+        tab2.sessions = [session2]
+        window2.tabs = [tab2]
+        window2.current_tab = tab2
+
+        # Add second window
+        mock_app.terminal_windows.append(window2)
+        mock_app.windows.append(window2)
+
+        async with client_session() as client:
+            # List all sessions across windows
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+
+            # Should have sessions from both windows
+            assert len(sessions) == 2
+            window_ids = {s["window_id"] for s in sessions}
+            assert window_ids == {"w0", "w1"}
+
+            # Focus session in second window
+            result = await client.call_tool(
+                "focus_session", {"session_id": "w1t0p0:second-window-session"}
+            )
+            focus_result = result.structuredContent
+            assert focus_result["success"] is True
+
+            # Verify second window was activated (at least once)
+            window2.async_activate.assert_called()
+            tab2.async_select.assert_called()
+            session2.async_activate.assert_called()
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_error_recovery(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test error recovery in workflow."""
+        async with client_session() as client:
+            # First call succeeds
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+            assert len(sessions) == 1
+
+            # Make connection fail for next call
+            mock_iterm2_for_mcp.Connection.async_create.side_effect = Exception(
+                "Connection lost"
+            )
+
+            # List sessions should return empty list
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+            assert sessions == []
+
+            # Focus should fail gracefully
+            result = await client.call_tool(
+                "focus_session", {"session_id": "any-session"}
+            )
+            focus_result = result.structuredContent
+            assert focus_result["success"] is False
+            assert "Failed" in focus_result["message"]
+
+            # Reset connection
+            mock_iterm2_for_mcp.Connection.async_create.side_effect = None
+            mock_iterm2_for_mcp.Connection.async_create.return_value = (
+                mock_iterm2_for_mcp.AsyncMock()
+            )
+
+            # Should work again
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+            assert len(sessions) == 1
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_concurrent_operations(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test concurrent tool calls."""
+        import asyncio
+
+        async with client_session() as client:
+            # Run multiple operations concurrently
+            tasks = [
+                client.call_tool("list_sessions", {}),
+                client.call_tool("get_current_session", {}),
+                client.call_tool("list_sessions", {}),  # Duplicate intentionally
+            ]
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            # All should succeed
+            assert len(results) == 3
+            for result in results:
+                assert not isinstance(result, Exception)
+                assert result.structuredContent is not None
+
+    @skip_if_no_mcp
+    def test_mcp_main_import(self):
+        """Test that MCP main can be imported."""
+        # This tests that the __main__.py module works correctly
+        assert mcp_main is not None
+        assert callable(mcp_main)
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_empty_terminal_state(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test behavior when iTerm2 has no windows/sessions."""
+        # Get mock app and clear it
+        mock_app = await mock_iterm2_for_mcp.async_get_app()
+        mock_app.terminal_windows = []
+        mock_app.windows = []
+        mock_app.current_terminal_window = None
+
+        async with client_session() as client:
+            # List sessions should return empty
+            result = await client.call_tool("list_sessions", {})
+            sessions = result.structuredContent["result"]
+            assert sessions == []
+
+            # Get current should return None
+            result = await client.call_tool("get_current_session", {})
+            current = result.structuredContent["result"]
+            assert current is None
+
+            # Focus should fail
+            result = await client.call_tool(
+                "focus_session", {"session_id": "any-session"}
+            )
+            focus_result = result.structuredContent
+            assert focus_result["success"] is False
+            assert "not found" in focus_result["message"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,132 @@
+"""Tests for the iterm2-focus MCP server."""
+
+import pytest
+
+from tests.conftest import MCP_TEST_AVAILABLE, skip_if_no_mcp
+
+if MCP_TEST_AVAILABLE:
+    from iterm2_focus.mcp import MCP_AVAILABLE
+
+
+class TestMCPServer:
+    """Test basic MCP server functionality."""
+
+    @skip_if_no_mcp
+    def test_mcp_available(self):
+        """Test that MCP is available when requirements are met."""
+        assert MCP_AVAILABLE is True
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_create_server(self, mcp_server):
+        """Test MCP server creation."""
+        assert mcp_server is not None
+        assert mcp_server.name == "iterm2-focus"
+        # Description and version are passed but not exposed as attributes
+        assert hasattr(mcp_server, "_mcp_server")
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_list_tools(self, mcp_server, client_session):
+        """Test that all tools are registered."""
+        async with client_session() as client:
+            tools = await client.list_tools()
+
+            # Check that we have exactly 3 tools
+            assert len(tools.tools) == 3
+
+            # Check tool names
+            tool_names = {tool.name for tool in tools.tools}
+            expected_tools = {"list_sessions", "focus_session", "get_current_session"}
+            assert tool_names == expected_tools
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_tool_descriptions(self, mcp_server, client_session):
+        """Test that tools have proper descriptions."""
+        async with client_session() as client:
+            tools = await client.list_tools()
+
+            for tool in tools.tools:
+                assert tool.description is not None
+                assert len(tool.description) > 0
+
+                # Check specific descriptions
+                if tool.name == "list_sessions":
+                    assert "List all available iTerm2 sessions" in tool.description
+                elif tool.name == "focus_session":
+                    assert "Focus a specific iTerm2 session by ID" in tool.description
+                elif tool.name == "get_current_session":
+                    assert (
+                        "Get information about the currently focused"
+                        in tool.description
+                    )
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_tool_schemas(self, mcp_server, client_session):
+        """Test that tools have proper input/output schemas."""
+        async with client_session() as client:
+            tools = await client.list_tools()
+
+            for tool in tools.tools:
+                # Check input schemas
+                if tool.name == "focus_session":
+                    # focus_session should have required session_id parameter
+                    assert tool.inputSchema is not None
+                    assert "properties" in tool.inputSchema
+                    assert "session_id" in tool.inputSchema["properties"]
+                    assert "required" in tool.inputSchema
+                    assert "session_id" in tool.inputSchema["required"]
+                elif tool.name in ["list_sessions", "get_current_session"]:
+                    # These tools don't require input
+                    if tool.inputSchema:
+                        assert tool.inputSchema.get("required", []) == []
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_server_capabilities(self, mcp_server):
+        """Test server capabilities."""
+        # Check that the server has the expected capabilities
+        assert hasattr(mcp_server, "_mcp_server")
+
+        # The server should support tools (capabilities are auto-discovered)
+        # We can't directly call get_capabilities without a request context
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_tool_error_handling(
+        self, mcp_server, client_session, mock_iterm2_for_mcp
+    ):
+        """Test error handling when iTerm2 connection fails."""
+        # Make the connection fail
+        mock_iterm2_for_mcp.Connection.async_create.side_effect = Exception(
+            "Connection failed"
+        )
+
+        async with client_session() as client:
+            # Try to list sessions
+            result = await client.call_tool("list_sessions", {})
+
+            # Should return empty list on error via structured content
+            assert (
+                result.isError is False
+            )  # Tool returns [] on error, not an error result
+            assert result.structuredContent is not None
+            assert result.structuredContent == {"result": []}
+
+    @skip_if_no_mcp
+    @pytest.mark.anyio
+    async def test_invalid_tool_call(self, mcp_server, client_session):
+        """Test calling a non-existent tool."""
+        async with client_session() as client:
+            result = await client.call_tool("non_existent_tool", {})
+
+            # FastMCP returns an error result instead of raising an exception
+            assert result.isError is True
+            # Check that error message indicates unknown tool
+            error_content = result.content[0]
+            assert (
+                "unknown tool" in error_content.text.lower()
+                or "not found" in error_content.text.lower()
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -364,6 +364,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -507,12 +516,14 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "black" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "twine" },
     { name = "types-click" },
@@ -524,6 +535,7 @@ mcp = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "black" },
     { name = "ipython" },
     { name = "mcp", extra = ["cli"] },
@@ -533,6 +545,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "twine" },
     { name = "types-click" },
@@ -540,6 +553,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "iterm2", specifier = ">=2.7" },
@@ -550,6 +564,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.11.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "types-click", marker = "extra == 'dev'", specifier = ">=7.1.0" },
@@ -557,6 +572,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "black", specifier = ">=23.0.0" },
     { name = "ipython", specifier = ">=8.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
@@ -566,6 +582,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.11.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "twine", specifier = ">=5.0.0" },
     { name = "types-click", specifier = ">=7.1.0" },
@@ -1117,6 +1134,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923 },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite for the MCP (Model Context Protocol) server functionality that was previously implemented in #6.

## Changes
- 🧪 Add test suite following the official MCP Python SDK patterns
- 🎯 Test all three MCP tools: `list_sessions`, `focus_session`, `get_current_session`
- 🔄 Add integration tests for full workflows and concurrent operations
- 🛡️ Mock iTerm2 connections to prevent real API calls during testing
- 📦 Add test dependencies: `anyio` and `pytest-xdist`
- 📊 Achieve 91% test coverage for MCP tools

## Test Structure
```
tests/
├── conftest.py              # Pytest configuration with MCP fixtures
├── test_mcp_server.py       # Basic server functionality tests
├── test_iterm_tools.py      # Individual MCP tool tests
└── test_mcp_integration.py  # Full workflow integration tests
```

## Testing Approach
The test suite follows the patterns established in the official MCP Python SDK:
- Uses memory transport for in-memory client-server testing
- Tests tool registration, execution, and error handling
- Validates structured content responses
- Ensures proper parameter validation
- Tests concurrent operations

## Coverage
The MCP implementation now has 91% test coverage:
- `mcp/tools/iterm_tools.py`: 91%
- `mcp/server.py`: 100%
- Overall project coverage: 88%

## Related PRs
- #6 - Original MCP server implementation

## Testing
```bash
# Run MCP tests only
uv run pytest tests/test_mcp*.py tests/test_iterm_tools.py -v

# Run all tests with coverage
make test-cov
```