### PR TITLE
docs: remove hardcoded user path from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ uv pip install iterm2-focus
 Send a macOS notification that focuses the current iTerm2 session when clicked:
 
 ```bash
-terminal-notifier -title "Task Complete" -message "Click to focus" -execute "/Users/masatomokusaka/.local/bin/uvx iterm2-focus $ITERM_SESSION_ID"
+terminal-notifier -title "Task Complete" -message "Click to focus" -execute "$(which uvx) iterm2-focus $ITERM_SESSION_ID"
 ```
 
-Note: Replace `/Users/masatomokusaka/.local/bin/uvx` with your actual uvx path (find it with `which uvx`). Requires `terminal-notifier` (`brew install terminal-notifier`).
+Note: Requires `terminal-notifier` (`brew install terminal-notifier`).
 
 ## Quick Usage (without installation)
 


### PR DESCRIPTION
## Summary
- Replace hardcoded path `/Users/masatomokusaka/.local/bin/uvx` with dynamic `$(which uvx)` command
- Remove unnecessary instruction to replace the path manually
- Make the terminal-notifier example work on any system

## Test plan
- [ ] Verify the `$(which uvx)` command works correctly in the terminal-notifier example
- [ ] Confirm the documentation is clear and no other hardcoded paths remain